### PR TITLE
reduce login calls

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.1
+          go-version: 1.25.1
       - name: "Check format"
         run: "test -z $(gofmt -l .)"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.1
+          go-version: 1.25.1
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Serviceware/vault-plugin-secrets-keycloak
 
-go 1.24.1
+go 1.25.1
 
 require (
 	github.com/Nerzal/gocloak/v13 v13.9.0

--- a/path_client_secret_test.go
+++ b/path_client_secret_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"testing/synctest"
+	"time"
 
 	"github.com/Serviceware/vault-plugin-secrets-keycloak/keycloak"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBackend_ReadClientSecretDeprecated(t *testing.T) {
@@ -147,6 +150,90 @@ func TestBackend_ReadClientSecret(t *testing.T) {
 		t.Fatalf("Expected: %#v\nActual: %#v", expectedResponse, resp.Data)
 	}
 }
+
+func TestBackend_OnlyLoginWhenNecessary(t *testing.T) {
+	config := logical.TestBackendConfig()
+	config.StorageView = &logical.InmemStorage{}
+	err := writeConfig(t.Context(), config.StorageView, ConnectionConfig{
+		ClientId:     "vault",
+		ClientSecret: "secret123",
+		Realm:        "somerealm",
+		ServerUrl:    "http://example.com/auth",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// TODO: Provide common mock setup elsewhere and use it here.
+	requestedClientId := "myclient"
+	makeMock := func(expiresIn time.Duration) *keycloak.MockService {
+		gocloakClientMock := &keycloak.MockService{}
+		gocloakClientMock.On("LoginClient", mock.Anything, "vault", "secret123", "somerealm").Return(
+			&keycloak.JWT{AccessToken: "access123",
+				ExpiresIn: int(expiresIn / time.Second),
+			}, nil)
+		idOfRequestedClient := "123"
+		gocloakClientMock.On("GetClients", mock.Anything, "access123", "somerealm", keycloak.GetClientsParams{ClientID: &requestedClientId}).Return(
+			[]*keycloak.Client{{ID: &idOfRequestedClient}}, nil)
+		secretValue := "mysecret123"
+		gocloakClientMock.On("GetClientSecret", mock.Anything, "access123", "somerealm", idOfRequestedClient).Return(
+			&keycloak.CredentialRepresentation{Value: &secretValue}, nil)
+		gocloakClientMock.On("GetWellKnownOpenidConfiguration", mock.Anything, "somerealm").Return(
+			&keycloak.WellKnownOpenidConfiguration{Issuer: "THIS_IS_THE_ISSUER"}, nil)
+		return gocloakClientMock
+	}
+
+	tests := []struct {
+		name                  string
+		expiresIn             time.Duration
+		waitDuration          time.Duration
+		expectedNumberOfCalls int
+	}{
+		{name: "expired token", expiresIn: 0, expectedNumberOfCalls: 2},
+		{name: "valid token", expiresIn: 60 * time.Second, expectedNumberOfCalls: 1},
+		{name: "token expired after wait time", expiresIn: 60 * time.Second, waitDuration: 61 * time.Second, expectedNumberOfCalls: 2},
+		{name: "token valid but above safety threshold", expiresIn: 60 * time.Second, waitDuration: 56 * time.Second, expectedNumberOfCalls: 2},
+		{name: "token still valid after waiting", expiresIn: 60 * time.Second, waitDuration: 30 * time.Second, expectedNumberOfCalls: 1},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				b, err := newBackend(config)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				client := makeMock(test.expiresIn)
+				b.KeycloakServiceFactory = keycloak.MockServiceFactoryFunc(client)
+				if err = b.Setup(t.Context(), config); err != nil {
+					t.Fatal(err)
+				}
+
+				request := &logical.Request{
+					Operation: logical.ReadOperation,
+					Path:      "clients/" + requestedClientId + "/secret",
+					Storage:   config.StorageView,
+				}
+				// First request: Expect login and retrieve a token as we do not have one, initially.
+				resp, err := b.HandleRequest(t.Context(), request)
+				require.NoError(t, err)
+				require.False(t, resp != nil && resp.IsError())
+
+				time.Sleep(test.waitDuration)
+
+				// Second request after sleeping:
+				// Based on the concrete test case we might need to login again and request a new token.
+				resp, err = b.HandleRequest(t.Context(), request)
+				require.NoError(t, err)
+				require.False(t, resp != nil && resp.IsError())
+
+				client.AssertNumberOfCalls(t, "LoginClient", test.expectedNumberOfCalls)
+			})
+		})
+	}
+}
+
 func TestBackend_ReadClientSecretWhenNotExists(t *testing.T) {
 	var resp *logical.Response
 	var err error


### PR DESCRIPTION
Currently, the plugin calls keycloak for authentication for every operation. This pull request aims to change that: Once an authentication token is acquired, it is kept and reused, if it is still valid when the plugin is tasked with the next opration.